### PR TITLE
feat(nvim/navigation): use `-` key to browse parent directory

### DIFF
--- a/nvim/.config/nvim/autoload/ppm/functions.vim
+++ b/nvim/.config/nvim/autoload/ppm/functions.vim
@@ -44,10 +44,10 @@ endfunction
 " Thx to http://travisjeffery.com/b/2011/11/saving-files-in-nonexistent-directories-with-vim/
 function! ppm#functions#auto_mkdir(dir, force)
   if !isdirectory(a:dir)
+        \   && (a:dir !~ '^oil:')
         \   && (a:force
         \       || input("'" . a:dir . "' does not exist. Create? [y/N] ") =~? '^y\%[es]$')
     call mkdir(a:dir, 'p')
   endif
 endfunction
 " }}} ppm#functions#auto_mkdir "
-

--- a/nvim/.config/nvim/lua/plugins/navigation.lua
+++ b/nvim/.config/nvim/lua/plugins/navigation.lua
@@ -1,4 +1,5 @@
 local config = require("ppm.utils").lazy_config
+local k = require("ppm.keymaps");
 
 return {
   {
@@ -52,8 +53,15 @@ return {
     "stevearc/oil.nvim",
     event = "VeryLazy",
     dependencies = { "nvim-tree/nvim-web-devicons" },
+    keys = {
+      { "-", "<CMD>Oil<CR>", { desc = "Browse parent directory" } },
+    },
     opts = {
       delete_to_trash = true,
+      keymaps = {
+        [k.Ctrl(k.vsplit)] = "actions.select_vsplit",
+        [k.Ctrl(k.split)] = "actions.select_split",
+      },
       view_options = {
         show_hidden = true,
       }
@@ -81,11 +89,11 @@ return {
         send_to_qflist = "<C-q>",
       },
     },
-    keys = function (plugin)
+    keys = function(plugin)
       local sj = require(plugin.name)
 
       return {
-        { "Z", sj.run, mode = "n" },
+        { "Z",              sj.run,                                          mode = "n" },
         { "<localleader>Z", function() sj.run({ select_window = true }) end, mode = "n" },
       }
     end,

--- a/nvim/.config/nvim/lua/ppm/keymaps.lua
+++ b/nvim/.config/nvim/lua/ppm/keymaps.lua
@@ -60,4 +60,8 @@ M.surround = {
   },
 }
 
+M.Ctrl = function (key)
+  return "<C-" .. key .. ">"
+end
+
 return M


### PR DESCRIPTION
1. Use `-` to open parent directory with [oil.nvim](https://github.com/stevearc/oil.nvim).
2. Disable automatic mkdir prompt for `oil:` protocol. 