### PR TITLE
fix(build/neovim/macos): use HEAD of utf8proc

### DIFF
--- a/include/make/target-neovim.macos.mk
+++ b/include/make/target-neovim.macos.mk
@@ -1,5 +1,6 @@
 install-neovim::
 	@brew install -q luajit luajit-openresty luarocks
+	@brew install -q --HEAD utf8proc || exit 0
 	@brew install -q --HEAD tree-sitter || exit 0
 	@brew install -q --HEAD neovim || exit 0
 	@$(MAKE) postinstall-neovim
@@ -11,6 +12,7 @@ install-neovim-dependencies::
 
 update-neovim::
 	@brew upgrade -q luajit luajit-openresty luarocks
+	@brew upgrade -q --fetch-HEAD utf8proc || exit 0
 	@brew upgrade -q --fetch-HEAD tree-sitter || exit 0
 	@brew upgrade -q --fetch-HEAD neovim || exit 0
 	@$(MAKE) postinstall-neovim

--- a/zsh/.config/zsh/plugins/macos/init.zsh
+++ b/zsh/.config/zsh/plugins/macos/init.zsh
@@ -17,9 +17,12 @@
   CPPFLAGS="-I${PPM_BREW_PREFIX}/opt/curl/include ${CPPFLAGS}"
   LDFLAGS="-L${PPM_BREW_PREFIX}/opt/ruby/lib ${LDFLAGS}"
   CPPFLAGS="-I${PPM_BREW_PREFIX}/opt/ruby/include ${CPPFLAGS}"
+  LDFLAGS="-L${PPM_BREW_PREFIX}/opt/luajit-openresty/lib ${LDFLAGS}"
+  CPPFLAGS="-I${PPM_BREW_PREFIX}/opt/luajit-openresty/include ${CPPFLAGS}"
 
   export LDFLAGS
   export CPPFLAGS
+  export PKG_CONFIG_PATH="${PPM_BREW_PREFIX}/opt/luajit-openresty/lib/pkgconfig:${PKG_CONFIG_PATH}"
 
   alias -g ls='ls --color=auto'
 

--- a/zsh/.config/zsh/plugins/macos/path.zsh
+++ b/zsh/.config/zsh/plugins/macos/path.zsh
@@ -6,4 +6,6 @@ path+=(
   "$PPM_BREW_PREFIX"/bin
   "$PPM_BREW_PREFIX"/opt/ruby/bin
   "$PPM_BREW_PREFIX"/opt/curl/bin
+  "$PPM_BREW_PREFIX"/opt/rustup/bin
+  "$PPM_BREW_PREFIX"/opt/luajit-openresty/bin
 )


### PR DESCRIPTION
As I use the HEAD version of Neovim on macOS, I also need to install the HEAD version of `utf8proc`.